### PR TITLE
Add steps to publish built docs, add playbook for field

### DIFF
--- a/docsbuilder-example.yml
+++ b/docsbuilder-example.yml
@@ -5,6 +5,8 @@
     - ka_lite_distributed_git_branch: develop
     - kalite_source_dest: /vagrant/source
     - docs_output_dir: /vagrant/output
+    - docs_html_host_dir: /vagrant/www/html
+    - docs_pdf_host_dir: /vagrant/www/pdfs
   roles:
     - common
     - server

--- a/field.yml
+++ b/field.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: field
+  vars:
+    - ka_lite_distributed_git_branch: develop
+    - kalite_source_dest: ~/docs/ka-lite-source
+    - docs_output_dir: ~/docs/output
+    - docs_html_host_dir: /usr/share/nginx/html/docs
+    - docs_pdf_host_dir: /usr/share/nginx/html/docspdf
+  roles:
+    - common
+    - server
+    - docsbuilder

--- a/roles/docsbuilder/tasks/main.yml
+++ b/roles/docsbuilder/tasks/main.yml
@@ -36,10 +36,16 @@
   sudo: yes
 
 - name: Build the pdfs from the latex
-  command: make -C {{ docs_output_dir }}/latex/en all-pdf
+  command: make -C {{ docs_output_dir }}/latex/{{ item }} all-pdf
   with_items: available_languages
   sudo: yes
 
-- name: Push the built docs to the server (a no-op right now)
-  shell: echo "Make me :( :( :("
+- name: Push the built html docs to the server
+  command: cp -r {{ docs_output_dir }}/html/en {{ docs_html_host_dir }}
+  with_items: available_languages
+  sudo: yes
+
+- name: Push the built pdf docs to the server
+  command: cp {{ docs_output_dir }}/latex/en/*.pdf {{ docs_pdf_host_dir }}/.
+  with_items: available_languages
   sudo: yes


### PR DESCRIPTION
Last two tasks will need to be altered once we have a translation workflow in place. This should be good to go. Will also need to remove current scheduled task in the field server to build the docs. And perhaps a scheduled task should be added to run this playbook (so docs are consistently updated)?