### PR TITLE
Delete kalite source dir, in case we run the same role with another s…

### DIFF
--- a/roles/docsbuilder/tasks/main.yml
+++ b/roles/docsbuilder/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Delete the source destination, if it exists
+  file: path={{ kalite_source_dest }} state=absent
+
 - name: Clone the ka-lite git repository and checkout the desired branch.
   git: repo=https://github.com/learningequality/ka-lite.git version={{ ka_lite_distributed_git_branch }} dest={{ kalite_source_dest }} update=true force=yes recursive=no
 


### PR DESCRIPTION
…et of variables

@aronasorman 

I was running the same role twice on field with two sets of variables (to build the 0.13.x docs and the develop docs), but I ran into trouble because of "ghost" modules when switching branches, since pyc files are no longer deleted on startup. Solution: remove the source before cloning.