### PR TITLE
Use signed cookies for the central server.

### DIFF
--- a/roles/keep/templates/local_settings.py.j2
+++ b/roles/keep/templates/local_settings.py.j2
@@ -32,7 +32,9 @@ DATABASES = {
     }
 }
 
-SESSION_ENGINE = "django.contrib.sessions.backends.file"
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 CENTRAL_WIKI_URL = "https://sites.google.com/a/learningequality.org/kalite/"
 


### PR DESCRIPTION
So we avoid making tons of files.