### PR TITLE
0.15 demo server playbook

### DIFF
--- a/demo.yml
+++ b/demo.yml
@@ -1,0 +1,8 @@
+- hosts: field
+  vars:
+    - ka_lite_distributed_port: 8009
+    - ka_lite_distributed_git_branch: 0.15.x
+    - ka_lite_distributed_prefix: ka-lite-develop-demo
+    - ka_lite_distributed_settings_module: kalite.project.settings.demo
+  roles:
+    - distributed

--- a/roles/distributed/tasks/main.yml
+++ b/roles/distributed/tasks/main.yml
@@ -86,7 +86,9 @@
   sudo_user: www-data
 
 - name: Run/restart the distributed server.
-  shell: "/var/www/{{ ka_lite_distributed_prefix }}/bin/kalite restart"
+  shell: "/var/www/{{ ka_lite_distributed_prefix }}/bin/kalite restart --settings={{ ka_lite_distributed_settings_module }} --port={{ ka_lite_distributed_port }}"
   sudo: yes
   sudo_user: www-data
+  tags:
+    - startkalite
   # when: ka_lite_distributed_clone.changed

--- a/roles/distributed/tasks/main.yml
+++ b/roles/distributed/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: add the nodejs ppa
+  shell: curl -sL https://deb.nodesource.com/setup | sudo bash -
+  sudo: yes
+  tags:
+    - setupnodejs
+
+- name: install nodejs
+  apt: name=nodejs
+  sudo: yes
+  tags:
+    - setupnodejs
 
 - name: Create the /var/www directory and set it as belonging to the www-data user.
   file: dest=/var/www owner=www-data state=directory
@@ -39,6 +50,26 @@
   when: ka_lite_distributed_django_superuser_name is defined and ka_lite_distributed_django_superuser_email is defined and ka_lite_distributed_django_superuser_pass is defined
   changed_when: "'Migrating forwards' in setup.stdout"
   # failed_when: "setup.stderr"
+
+- name: download nodejs deps
+  shell: npm install
+  args:
+    chdir: /var/www/{{ ka_lite_distributed_prefix }}/
+  sudo: yes
+  sudo_user: www-data
+  register: setup
+  tags:
+    - setupassets
+
+- name: Build static files
+  shell: node build.js
+  args:
+    chdir: /var/www/{{ ka_lite_distributed_prefix }}/
+  sudo: yes
+  sudo_user: www-data
+  register: setup
+  tags:
+    - setupassets
 
 - name: Run setup command to ensure KA Lite is initialized (upgrade).
   shell: "echo 'yes\n' | /var/www/{{ ka_lite_distributed_prefix }}/bin/kalite manage setup --noinput"

--- a/roles/distributed/vars/main.yml
+++ b/roles/distributed/vars/main.yml
@@ -1,5 +1,3 @@
 ---
-
-ka_lite_distributed_git_branch: master
 ka_lite_distributed_path: /var/www/ka-lite
 ka_lite_distributed_channel: khan


### PR DESCRIPTION
Creates a new playbook, `demo.yml`, that sets up 0.15+ demo servers. Not sure if it works for 0.14, I'll try that for another day.