### PR TITLE
Kolibri demo server setup

### DIFF
--- a/roles/content-curation/templates/nginx.content-curation.conf.j2
+++ b/roles/content-curation/templates/nginx.content-curation.conf.j2
@@ -1,4 +1,4 @@
-upstream app_server {
+upstream content_curation_server {
   # fail_timeout=0 means we always retry an upstream even if it failed
   # to return a good HTTP response (in case the Unicorn master nukes a
   # single worker for timing out).
@@ -8,6 +8,8 @@ upstream app_server {
 
 
 server {
+
+    server_name unicefcontentcuration.learningequality.org;
 
     listen 80;
 
@@ -24,6 +26,16 @@ server {
     location /storage/ {
         autoindex on;
         root /var/www/{{ content_curation_prefix }}_storage/;
+    }
+
+    location /content/storage/ {
+        autoindex on;
+        root /var/www/{{ content_curation_prefix }}_storage/;
+    }
+
+    location /content/databases/ {
+        autoindex off;
+        root /var/www/{{ content_curation_prefix}}_content_db_export/;
     }
 
     location / {
@@ -53,7 +65,7 @@ server {
         # Try to serve static files from nginx, no point in making an
         # *application* server like Unicorn/Rainbows! serve static files.
         if (!-f $request_filename) {
-            proxy_pass http://app_server;
+            proxy_pass http://content_curation_server;
             break;
         }
     }

--- a/roles/gatehouse/vars/main.yml
+++ b/roles/gatehouse/vars/main.yml
@@ -60,6 +60,10 @@ proxy_backends:
     host: 192.237.179.50
     port: 80
 
+  - name: unicef_kolibri_demo
+    host: 192.237.179.50
+    port: 80
+
   - name: old_adhocsync_dev_server
     host: 174.129.228.112
     port: 7007
@@ -199,6 +203,9 @@ virtual_hosts:
       - unicefcontentcuration.learningequality.org
     backend: unicef_content_curation
 
+  - hosts:
+      - kolibridemo.learningequality.org
+    backend: unicef_kolibri_demo
 
   - hosts:
       - dashboard.learningequality.org

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: copy over kolibri pex file
+  copy: src=./kolibri-static-0.0.1.dev20160726004902.pex dest=/var/www/kolibri-static.pex
+  sudo: yes
+  sudo_user: www-data
+  tags:
+    - setupkolibri
+
+- name: super hack hack hack copy the export staging sqlite file from the content curation server
+  command: cp /var/www/{{ content_curation_prefix }}/contentcuration/export_staging.sqlite3 ~/.kolibri/content/databases/dummy_db.sqlite3
+  sudo: yes
+  sudo_user: www-data
+  tags:
+    - setupkolibri
+
+- name: super hack hack hack make a symbolic link from the content curation storage dir to kolibri home
+  shell: mkdir -p ~/.kolibri/content/ && ln -s /var/www/{{ content_curation_prefix }}_storage/ ~/.kolibri/content/storage
+  sudo: yes
+  sudo_user: www-data
+  tags:
+    - setupkolibri
+
+- name: allow port 8199 on our firewall
+  ufw: policy=allow to_port=8199
+  sudo: yes
+  tags:
+    - setupkolibri
+
+
+- name: add nginx setup
+  template: src=nginx.kolibriprod.conf.j2 dest=/etc/nginx/sites-enabled/kolibri mode='u=rw,g=r,o=r'
+  notify: restart nginx
+  sudo: yes
+  tags:
+    - setupnginx
+    - setupkolibri
+
+# - name: stop the existing kolibri process
+#   command: /var/www/kolibri-static.pex stop
+#   sudo: yes
+#   sudo_user: www-data
+#   ignore_errors: true
+#   tags:
+#     - setupkolibri
+
+# - name: start kolibri
+#   command: /var/www/kolibri-static.pex start
+#   sudo: yes
+#   sudo_user: www-data
+#   tags:
+#     - setupkolibri

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: copy over kolibri pex file
-  copy: src=./kolibri-static-0.0.1.dev20160726004902.pex dest=/var/www/kolibri-static.pex
+  copy: src=./kolibri-static.pex dest=/var/www/kolibri-static.pex
   sudo: yes
   sudo_user: www-data
   tags:

--- a/roles/kolibri/templates/nginx.kolibriprod.conf.j2
+++ b/roles/kolibri/templates/nginx.kolibriprod.conf.j2
@@ -1,0 +1,52 @@
+upstream kolibri_server {
+  server 127.0.0.1:8080;
+}
+
+server {
+  server_name kolibridemo.learningequality.org;
+
+  listen 80;
+
+  client_max_body_size 4G;
+
+  access_log /var/log/nginx-access.log;
+  error_log /var/log/nginx-error.log debug;
+
+  location / {
+# an HTTP header important enough to have its own Wikipedia entry:
+#   http://en.wikipedia.org/wiki/X-Forwarded-For
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+# enable this if and only if you use HTTPS, this helps Rack
+# set the proper protocol for doing redirects:
+# proxy_set_header X-Forwarded-Proto https;
+
+# pass the Host: header from the client right along so redirects
+# can be set properly within the Rack application
+    proxy_set_header Host $http_host;
+
+# we don't want nginx trying to do something clever with
+# redirects, we set the Host: header above already.
+    proxy_redirect off;
+
+# set "proxy_buffering off" *only* for Rainbows! when doing
+# Comet/long-poll stuff.  It's also safe to set if you're
+# using only serving fast clients with Unicorn + nginx.
+# Otherwise you _want_ nginx to buffer responses to slow
+# clients, really.
+# proxy_buffering off;
+
+# Try to serve static files from nginx, no point in making an
+    # *application* server like Unicorn/Rainbows! serve static files.
+      if (!-f $request_filename) {
+        proxy_pass http://kolibri_server;
+        break;
+      }
+  }
+
+  # # Error pages
+# error_page 500 502 503 504 /500.html;
+# location = /500.html {
+#     root /webapps/hello_django/static/;
+    # }
+}

--- a/unicef-content-curation.yml
+++ b/unicef-content-curation.yml
@@ -7,3 +7,4 @@
     - server
     - design-guide
     - content-curation
+    - kolibri


### PR DESCRIPTION
to update the kolibri demo server:

- on the kolibri repo, run `make dist` (make sure your code has this PR's commits in: https://github.com/learningequality/kolibri/pull/299)
- copy dist/kolibri*.pex into the root of your `ansible-playbooks` and name it as `kolibri-static.pex`.
- Run the script: `ansible-playbook -i hosts unicef_content_curation.yml --tags setupkolibri`.
- profit.